### PR TITLE
removed swiftshader

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -209,7 +209,6 @@ async def get_webdriver_nd(proxy: dict = None) -> nd.Browser:
     # https://github.com/FlareSolverr/FlareSolverr/issues/782
     # https://github.com/microsoft/vscode/issues/127800#issuecomment-873342069
     # https://peter.sh/experiments/chromium-command-line-switches/#use-gl
-    options.add_argument("--use-gl=swiftshader")
 
     language = os.environ.get("LANG", None)
     if language is not None:
@@ -284,7 +283,6 @@ def get_webdriver_uc(proxy: dict = None) -> WebDriver:
     # https://github.com/FlareSolverr/FlareSolverr/issues/782
     # https://github.com/microsoft/vscode/issues/127800#issuecomment-873342069
     # https://peter.sh/experiments/chromium-command-line-switches/#use-gl
-    options.add_argument("--use-gl=swiftshader")
 
     language = os.environ.get("LANG", None)
     if language is not None:


### PR DESCRIPTION
Hello @21hsmw, thanks for proposing and maintaining this version of FlareSolverr which still works as of today!

I found it through Reddit and I noticed that it worked perfectly well on my computer. However, when I tried to run it on my NAS (Synology DS718+ but I think that plenty of NAS are in the same case), it was systematically crashing with the following log messages (that I have also seen in plenty of issues created in the original FlareSolverr repo):

```bash
2025/03/06 17:59:09 INFO     ReqId 139880755764096 FlareSolverr 3.4.0
2025/03/06 17:59:09 DEBUG    ReqId 139880755764096 Debug log enabled
2025/03/06 17:59:09 INFO     ReqId 139880755764096 WARNING: YOU ARE RUNNING AN UNOFFICIAL EXPERIMENTAL BRANCH OF FLARESOLVER WHICH MAY CONTAIN BUGS.
2025/03/06 17:59:09 INFO     ReqId 139880755764096 WARNING: IF YOU ENCOUNTER ANY, PLEASE REPORT THEM ON GITHUB AT THE FOLLOWING LINK:
2025/03/06 17:59:09 INFO     ReqId 139880755764096 WARNING: https://github.com/FlareSolverr/FlareSolverr/pull/1163
2025/03/06 17:59:09 DEBUG    ReqId 139880755764096 Using selector: EpollSelector
2025/03/06 17:59:09 INFO     ReqId 139880755764096 Testing web browser installation...
2025/03/06 17:59:09 INFO     ReqId 139880755764096 Platform: Linux-4.4.302+-x86_64-with-glibc2.36
2025/03/06 17:59:09 INFO     ReqId 139880755764096 Chrome / Chromium path: /bin/chromium
2025/03/06 17:59:09 INFO     ReqId 139880755764096 Chrome / Chromium major version: 133
2025/03/06 17:59:33 INFO     ReqId 139880755764096 Launching web browser...
2025/03/06 17:59:33 INFO     ReqId 139880755764096 Launching web browser...
2025/03/06 17:59:33 DEBUG    ReqId 139880755764096 Launching web browser with nodriver...
2025/03/06 17:59:34 DEBUG    ReqId 139880755764096 /usr/local/bin/chrome is not a valid candidate because don't exist or not executable
...
2025/03/06 17:59:46 stdout urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
    raise URLError(err)
  File "/usr/local/lib/python3.11/urllib/request.py", line 1351, in do_open
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/local/lib/python3.11/urllib/request.py", line 1377, in http_open
                      ^^^^^^^^^^^^
    result = func(*args)
  File "/usr/local/lib/python3.11/urllib/request.py", line 496, in _call_chain
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/local/lib/python3.11/urllib/request.py", line 536, in _open
                        ^^^^^^^^^^^^^^^^^^^^^^
    response = self._open(req, data)
  File "/usr/local/lib/python3.11/urllib/request.py", line 519, in open
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    return opener.open(url, data, timeout)
...
2025/03/06 17:59:58 stdout Exception: Error getting browser User-Agent. cannot access local variable 'driver' where it is not associated with a value
    raise Exception("Error getting browser User-Agent. " + str(e))
  File "/app/utils.py", line 486, in get_user_agent_nd
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    user_agent = await utils.get_user_agent_nd()
  File "/app/flaresolverr_service_nd.py", line 85, in test_browser_installation_nd
             ^^^^^^^^^^^^^^^^
    return future.result()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    return self._loop.run_until_complete(task)
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
                    ^^^^^^^^^^^^^^^^^
    return runner.run(main)
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    asyncio.run(flaresolverr_service_nd.test_browser_installation_nd())
  File "/app/flaresolverr.py", line 134, in <module>
Traceback (most recent call last):

During handling of the above exception, another exception occurred:

UnboundLocalError: cannot access local variable 'driver' where it is not associated with a value
              ^^^^^^
    return driver
  File "/app/utils.py", line 261, in get_webdriver_nd
             ^^^^^^^^^^^^^^^^^^^^^^^^^
    driver = await get_webdriver_nd()

```

After careful investigation, I managed to isolate the root cause of the issue and it seems to be the usage of swiftshader upon launching Chromium, which, for some reason cannot start with this configuration and almost immediately enters uninterruptable sleep (D+).

This behaviour is not really surprising on a NAS as it is not designed for GPU processing and, from what I understood, SwiftShader tries to emulate GPU rendering.

In any case, I found out that, by removing the argument "--use-gl=swiftshader", Chromium starts well and still manages to solve Cloudflare challenges. I tested it myself on my NAS and I can confirm this works. My version is also available on Docker hub if you want to check (hlaroussi/flaresolverr).

On top of that, I really don't think this will create any regression especially since the flag "--disable-gpu" is also present.

Let me know your thoughts on my PR proposal. I can make any  cleanups/changes if need be.